### PR TITLE
Validators per operator cap: 500 to 1000

### DIFF
--- a/all.md
+++ b/all.md
@@ -1,17 +1,18 @@
 ## All SIPS
 
-| SIP #                                 | Title                       | Status |
-|---------------------------------------|-----------------------------|--------|
-| [1](./sips/dkg.md)                    | DKG                         | open-for-discussion  |
-| [2](./sips/msg_struct_encoding.md)    | Message struct and encoding | open-for-discussion  |
-| [3](./sips/qbft_sync.md)              | QBFT Sync                   | open-for-discussion  |
-| [4](./sips/change_operator.md)        | Change operators set        | open-for-discussion  |
-| [5](./sips/ecies_share_encryption.md) | ECIES Share Encryption      | open-for-discussion  |
-| [6](./sips/constant_qbft_timeout.md)  | Constant QBFT timeout       | open-for-discussion  |
-| [7](./sips/fork_support.md)           | Fork Support                | open-for-discussion  |
-| [8](./sips/pre_consensus_livness.md)                    | Pre-Consensus livness fix   | open-for-discussion  |
-| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation | spec-merged |
-| [10](./sips/qbft_drop_redundant_bls.md) | Drop redundant BLS in QBFT | spec-merged  |
-| [11](./sips/eliminate_bls.md) | Eliminate BLS out of QBFT and change message structure    | spec-merged |
-| [12](./sips/topic_by_committe_id.md) | Eliminate BLS out of QBFT and change message structure    | spec-merged |
-| [13](./sips/cluster_consensus.md)      | Cluster-based consensus     | spec-merged |
+|                           SIP #                           |                         Title                          |       Status        |
+| --------------------------------------------------------- | ------------------------------------------------------ | ------------------- |
+| [1](./sips/dkg.md)                                        | DKG                                                    | open-for-discussion |
+| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | open-for-discussion |
+| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | open-for-discussion |
+| [4](./sips/change_operator.md)                            | Change operators set                                   | open-for-discussion |
+| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | open-for-discussion |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | open-for-discussion |
+| [7](./sips/fork_support.md)                               | Fork Support                                           | open-for-discussion |
+| [8](./sips/pre_consensus_livness.md)                      | Pre-Consensus livness fix                              | open-for-discussion |
+| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | spec-merged         |
+| [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | spec-merged         |
+| [11](./sips/eliminate_bls.md)                             | Eliminate BLS out of QBFT and change message structure | spec-merged         |
+| [12](./sips/topic_by_committe_id.md)                      | Eliminate BLS out of QBFT and change message structure | spec-merged         |
+| [13](./sips/cluster_consensus.md)                         | Cluster-based consensus                                | spec-merged         |
+| [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | spec-merged         |

--- a/core.md
+++ b/core.md
@@ -1,16 +1,17 @@
 ## Core
 
-| SIP #                              | Title                       | Status |
-|------------------------------------|-----------------------------|--------|
-| [1](./sips/dkg.md)                 | DKG                         | open-for-discussion  |
-| [2](./sips/msg_struct_encoding.md) | Message struct and encoding | open-for-discussion  |
-| [3](./sips/qbft_sync.md)           | QBFT Sync | open-for-discussion  |
-| [4](./sips/change_operator.md)     | Change operators set | open-for-discussion  |
-| [5](./sips/ecies_share_encryption.md) | ECIES Share Encryption      | open-for-discussion  |
-| [6](./sips/constant_qbft_timeout.md)  | Constant QBFT timeout      | open-for-discussion  |
-| [7](./sips/fork_support.md)           | Fork Support                | open-for-discussion  |
-| [8](./sips/pre_consensus_livness.md)                    | Pre-Consensus livness fix   | open-for-discussion  |
-| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation | spec-merged |
-| [10](./sips/qbft_drop_redundant_bls.md) | Drop redundant BLS in QBFT | spec-merged  |
-| [11](./sips/eliminate_bls.md) | Eliminate BLS out of QBFT and change message structure    | spec-merged |
-| [13](./sips/cluster_consensus.md)      | Cluster-based consensus     | spec-merged |
+|                           SIP #                           |                         Title                          |       Status        |
+| --------------------------------------------------------- | ------------------------------------------------------ | ------------------- |
+| [1](./sips/dkg.md)                                        | DKG                                                    | open-for-discussion |
+| [2](./sips/msg_struct_encoding.md)                        | Message struct and encoding                            | open-for-discussion |
+| [3](./sips/qbft_sync.md)                                  | QBFT Sync                                              | open-for-discussion |
+| [4](./sips/change_operator.md)                            | Change operators set                                   | open-for-discussion |
+| [5](./sips/ecies_share_encryption.md)                     | ECIES Share Encryption                                 | open-for-discussion |
+| [6](./sips/constant_qbft_timeout.md)                      | Constant QBFT timeout                                  | open-for-discussion |
+| [7](./sips/fork_support.md)                               | Fork Support                                           | open-for-discussion |
+| [8](./sips/pre_consensus_livness.md)                      | Pre-Consensus livness fix                              | open-for-discussion |
+| [9](./sips/partial_signature_verification_aggregation.md) | Partial Signature Verification Aggregation             | spec-merged         |
+| [10](./sips/qbft_drop_redundant_bls.md)                   | Drop redundant BLS in QBFT                             | spec-merged         |
+| [11](./sips/eliminate_bls.md)                             | Eliminate BLS out of QBFT and change message structure | spec-merged         |
+| [13](./sips/cluster_consensus.md)                         | Cluster-based consensus                                | spec-merged         |
+| [14](./sips/validators_per_operator_1k_cap.md)            | 1K cap on validators per operator                      | spec-merged         |

--- a/sips/validators_per_operator_1k_cap.md
+++ b/sips/validators_per_operator_1k_cap.md
@@ -39,7 +39,7 @@ Letting $v$ as the number of validators per operator, to account for attestation
 
 $$v + max(512, v)$$
 
-Before we had $500 + max(512,500) = 1000$, now, we have $1000 + max(512,1000) = 1512$.
+Before we had $500 + min(512,500) = 1000$, now, we have $1000 + min(512,1000) = 1512$.
 
 Thus, we need to change the `PartialSignatureMessages` structure in the following way:
 

--- a/sips/validators_per_operator_1k_cap.md
+++ b/sips/validators_per_operator_1k_cap.md
@@ -1,0 +1,61 @@
+|     Author     |               Title               | Category  |       Status        |    Date    |
+| -------------- | --------------------------------- | --------- | ------------------- | ---------- |
+| Matheus Franco | 1K cap on validators per operator | Contracts | open-for-discussion | 2024-11-28 |
+
+## Summary
+
+This SIP proposes increasing the cap on the number of validators per operator from 500 to 1000.
+
+## Motivation
+
+The recent optimizations allowed operators to reduce their operational costs while running the same number of validators, thus keeping the same profits. Therefore, this allows operators to further increase the size of their validator sets, keeping a sustainable processing cost and increasing their profitability.
+
+## Performance trade-offs
+
+To understand the performance impact, we compared two settings with the same number of validators (namely, 104k), one with a cap of 500 and the other of 1000 validators per operator. Using the 500 case as a benchmark, we got the following results for the 1000 case:
+
+| Metric                             | Impact     |
+|------------------------------------|------------|
+| Maximum operator cryptography cost | 20% higher |
+| Average operator cryptography cost | 80% higher |
+| Maximum operator message rate      | 30% lower  |
+| Average operator message rate      | 22% lower  |
+
+This behavior is expected. More validators per operator reduce the number of required operators and allow Committee Consensus to aggregate more duties. This promotes a reduction in the number of exchanged messages and non-committee message ratios. On the other hand, since the partial signature phase is the heaviest influence on the cryptography cost, increasing the cap from 500 to 1k inevitably increases the cryptography cost.
+
+> [!NOTE]
+> With the Pectra fork, dropping the `CommitteeIndex` field in the attestation beacon object will allow an operator to verify all post-consensus signatures in constant time. In other terms, currently, due to different `CommitteeIndex`s, the complexity of signatures verification on the post-consensus phase is $\mathcal{O}(d)$, where $d$ is the number of duties. After the Pectra fork, it will become $\mathcal{O}(1)$, significantly reducing the overall cryptography cost.
+
+## Security
+
+Post-consensus messages may increase their average and maximum sizes as shown in the [spec changes](#partialsignaturemessages). Nonetheless, it's still way smaller than a consensus proposal message. Thus, the proposed change doesn't introduce extra concerns on network security.
+
+## Spec changes
+
+### PartialSignatureMessages
+
+The proposed change influences the number of signatures a post-consensus message may have.
+Letting $v$ as the number of validators per operator, to account for attestation and sync committee duties, the maximum number of signatures per message is computed as
+
+$$v + max(512, v)$$
+
+Before we had $500 + max(512,500) = 1000$, now, we have $1000 + max(512,1000) = 1512$.
+
+Thus, we need to change the `PartialSignatureMessages` structure in the following way:
+
+```go
+type PartialSignatureMessages struct {
+    Type     PartialSigMsgType
+    Slot     phase0.Slot
+    Messages []*PartialSignatureMessage `ssz-max:"1512"` // Changed from 1000 to 1512
+}
+```
+
+### Message Validation
+
+In message validation, we need to update the following:
+- for the rule on the number of signatures contained in a post-consensus message, the limit must be changed from 1000 to 1512.
+- for the rules on the maximum byte size of a message, we have the new maximum sizes:
+  - maximum encoded `PartialSignatureMessages`: 144020 $\to$ 217748
+  - maximum encoded `SSVMessage` with encoded `PartialSignatureMessages`: 144088 $\to$ 217816
+  - maximum encoded `SignedSSVMessage` with encoded `PartialSignatureMessages`: 147588 $\to$ 221316

--- a/sips/validators_per_operator_1k_cap.md
+++ b/sips/validators_per_operator_1k_cap.md
@@ -21,7 +21,14 @@ To understand the performance impact, we compared two settings with the same num
 | Maximum operator message rate      | 30% lower  |
 | Average operator message rate      | 22% lower  |
 
-This behavior is expected. More validators per operator reduce the number of required operators and allow Committee Consensus to aggregate more duties. This promotes a reduction in the number of exchanged messages and non-committee message ratios. On the other hand, since the partial signature phase is the heaviest influence on the cryptography cost, increasing the cap from 500 to 1k inevitably increases the cryptography cost.
+This behavior is expected. More validators per operator reduce the number of required operators and allow Committee Consensus to aggregate more duties.
+This promotes a reduction in the number of exchanged messages and non-committee message ratios.
+On the other hand, since the partial signature phase is the heaviest influence on the cryptography cost,
+increasing the cap from 500 to 1k inevitably increases the cryptography cost.
+
+The difference between 20% (average between operators) and 80% (maximum operator) in the cryptography cost increase is due to the effects of Committee Consensus.
+Small and medium operators don't gain much from Committee Consensus, since the number of consensus instances increases linearly for a small number of validators.
+On the other hand, for large operators, the number of consensus instances stays fixed at 32 per epoch (despite the increase of validators).
 
 > [!NOTE]
 > With the Pectra fork, dropping the `CommitteeIndex` field in the attestation beacon object will allow an operator to verify all post-consensus signatures in constant time. In other terms, currently, due to different `CommitteeIndex`s, the complexity of signatures verification on the post-consensus phase is $\mathcal{O}(d)$, where $d$ is the number of duties. After the Pectra fork, it will become $\mathcal{O}(1)$, significantly reducing the overall cryptography cost.

--- a/sips/validators_per_operator_1k_cap.md
+++ b/sips/validators_per_operator_1k_cap.md
@@ -1,6 +1,6 @@
-|     Author     |               Title               | Category  |       Status        |    Date    |
-| -------------- | --------------------------------- | --------- | ------------------- | ---------- |
-| Matheus Franco | 1K cap on validators per operator | Contracts | open-for-discussion | 2024-11-28 |
+|     Author     |               Title               | Category  |   Status    |    Date    |
+| -------------- | --------------------------------- | --------- | ----------- | ---------- |
+| Matheus Franco | 1K cap on validators per operator | Contracts | spec-merged | 2024-11-28 |
 
 ## Summary
 

--- a/sips/validators_per_operator_1k_cap.md
+++ b/sips/validators_per_operator_1k_cap.md
@@ -44,7 +44,7 @@ Post-consensus messages may increase their average and maximum sizes as shown in
 The proposed change influences the number of signatures a post-consensus message may have.
 Letting $v$ as the number of validators per operator, to account for attestation and sync committee duties, the maximum number of signatures per message is computed as
 
-$$v + max(512, v)$$
+$$v + min(512, v)$$
 
 Before we had $500 + min(512,500) = 1000$, now, we have $1000 + min(512,1000) = 1512$.
 


### PR DESCRIPTION
## Overview

This SIP proposes changing the validators per operator cap from 500 to 1000. This change is possible due to the recent optimizations and allows a higher profitability per operator.