### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>ssvlabs/shared-configs//renovate/renovate.json"
+  ]
+}


### PR DESCRIPTION
This PR adds a Renovate config extending `ssvlabs/shared-configs`.